### PR TITLE
update checkout, verify email,

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CompilerConfiguration">
+    <annotationProcessing>
+      <profile name="Gradle Imported" enabled="true">
+        <outputRelativeToContentRoot value="true" />
+        <processorPath useClasspath="false">
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.projectlombok/lombok/1.18.30/f195ee86e6c896ea47a1d39defbe20eb59cd149d/lombok-1.18.30.jar" />
+        </processorPath>
+        <module name="backend.main" />
+      </profile>
+    </annotationProcessing>
+  </component>
+</project>

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     implementation 'org.flywaydb:flyway-core'
     implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
     implementation "com.cloudinary:cloudinary-http44:${cloudinaryVersion}"
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'org.postgresql:postgresql'
     annotationProcessor 'org.projectlombok:lombok'

--- a/backend/src/main/java/com/bookstore/backend/core/email/EmailService.java
+++ b/backend/src/main/java/com/bookstore/backend/core/email/EmailService.java
@@ -1,0 +1,74 @@
+package com.bookstore.backend.core.email;
+
+import com.bookstore.backend.book.Book;
+import com.bookstore.backend.book.BookService;
+import com.bookstore.backend.orders.LineItem;
+import com.bookstore.backend.orders.Order;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+import java.text.NumberFormat;
+import java.util.Locale;
+
+@Service
+public class EmailService {
+
+    private final JavaMailSender emailSender;
+    private final BookService bookService;
+    private static String from;
+
+    public EmailService(@Value("${spring.mail.username}") String from, JavaMailSender emailSender, BookService bookService) {
+        this.emailSender = emailSender;
+        this.bookService = bookService;
+        from = from;
+    }
+
+    public void sendConfirmationEmail(String to, String subject, String body) {
+        try {
+            SimpleMailMessage message = new SimpleMailMessage();
+            message.setFrom(from); // Địa chỉ Gmail của bạn
+            message.setTo(to);
+            message.setSubject(subject);
+            message.setText(body);
+            emailSender.send(message);
+        } catch (Exception e) {
+            throw new SendEmailFailureException("Failed to send email.");
+        }
+    }
+
+    public static String buildEmailVerifyBody(long otp) {
+        return "Mã xác thực của bạn là: " + otp;
+    }
+
+    public String buildEmailBody(Order order) {
+        var userInfo = order.getUserInformation();
+        var lineItemsString = new StringBuilder();
+        for (LineItem lineItem : order.getLineItems()) {
+            Book book = bookService.findByIsbn(lineItem.getIsbn());
+            lineItemsString.append(book.getTitle())
+                    .append(" x").append(lineItem.getQuantity()).append(" - ")
+                    .append(NumberFormat.getCurrencyInstance(new Locale("vi", "VN"))
+                            .format(book.getPrice())).append(" VND \n");
+        }
+        return new StringBuilder().append("Chào ").append(userInfo.getFullName()).append(", \n\n")
+                .append("Cảm ơn bạn đã đặt hàng tại Bookstore! \n\n")
+                .append("Đây là thông tin đơn hàng của bạn: \n\n")
+                .append("Mã đơn hàng: ").append(order.getId()).append(" \n")
+                .append("Kiểu nhận hàng: ").append(order.getPaymentMethod()).append(" \n")
+                .append("Ngày đặt: ").append(order.getCreatedDate()).append(" \n")
+                .append("Tổng tiền: ").append(NumberFormat.getCurrencyInstance(new Locale("vi", "VN"))
+                        .format(order.getTotalPrice())).append(" VND \n\n")
+                .append("Danh sách sản phẩm: \n")
+                .append(lineItemsString).append("\n\n")
+                .append("Thông tin địa chỉ nhận hàng: \n")
+                .append("Địa chỉ: ").append(userInfo.getAddress()).append(" \n")
+                .append("City: ").append(userInfo.getCity()).append(" , zipCode: ").append(userInfo.getZipCode()).append(" \n\n")
+                .append("Chúng tôi sẽ liên hệ với bạn sớm để xác nhận và giao hàng. \n")
+                .append("Trân trọng, \n")
+                .append("Bookstore support!").toString();
+    }
+
+}

--- a/backend/src/main/java/com/bookstore/backend/core/email/SendEmailFailureException.java
+++ b/backend/src/main/java/com/bookstore/backend/core/email/SendEmailFailureException.java
@@ -1,0 +1,7 @@
+package com.bookstore.backend.core.email;
+
+public class SendEmailFailureException extends RuntimeException {
+    public SendEmailFailureException(String msg) {
+        super(msg);
+    }
+}

--- a/backend/src/main/java/com/bookstore/backend/core/exception/EmailServiceAdvice.java
+++ b/backend/src/main/java/com/bookstore/backend/core/exception/EmailServiceAdvice.java
@@ -1,0 +1,24 @@
+package com.bookstore.backend.core.exception;
+
+import com.bookstore.backend.core.ApiError;
+import com.bookstore.backend.core.email.SendEmailFailureException;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.List;
+
+@RestControllerAdvice
+public class EmailServiceAdvice {
+
+    @ExceptionHandler(SendEmailFailureException.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public ApiError handleSendEmailFailureException(SendEmailFailureException ex) {
+        ApiError.ErrorInfo errorInfo = new ApiError.ErrorInfo();
+        errorInfo.setMessage(ex.getMessage());
+        return ApiError.builder()
+                .errors(List.of(errorInfo)).build();
+    }
+
+}

--- a/backend/src/main/java/com/bookstore/backend/core/exception/OrderControllerAdvice.java
+++ b/backend/src/main/java/com/bookstore/backend/core/exception/OrderControllerAdvice.java
@@ -2,8 +2,7 @@ package com.bookstore.backend.core.exception;
 
 import com.bookstore.backend.book.Book;
 import com.bookstore.backend.core.ApiError;
-import com.bookstore.backend.orders.exception.ConsistencyDataException;
-import com.bookstore.backend.orders.exception.OrderNotFoundException;
+import com.bookstore.backend.orders.exception.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -37,6 +36,33 @@ public class OrderControllerAdvice implements ControllerAdviceConfig {
     public ApiError handleOrderNotFound(OrderNotFoundException ex) {
         ApiError.ErrorInfo errorInfo = new ApiError.ErrorInfo();
         errorInfo.setEntity(Book.class.getSimpleName());
+        errorInfo.setMessage(ex.getMessage());
+        return ApiError.builder()
+                .errors(List.of(errorInfo)).build();
+    }
+
+    @ExceptionHandler(OtpExpiredException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ApiError handleOtpExpired(OtpExpiredException ex) {
+        ApiError.ErrorInfo errorInfo = new ApiError.ErrorInfo();
+        errorInfo.setMessage(ex.getMessage());
+        return ApiError.builder()
+                .errors(List.of(errorInfo)).build();
+    }
+
+    @ExceptionHandler(OrderStatusNotMatchException.class)
+    @ResponseStatus(HttpStatus.CONFLICT)
+    public ApiError handleOrderStatusNotMatch(OrderStatusNotMatchException ex) {
+        ApiError.ErrorInfo errorInfo = new ApiError.ErrorInfo();
+        errorInfo.setMessage(ex.getMessage());
+        return ApiError.builder()
+                .errors(List.of(errorInfo)).build();
+    }
+
+    @ExceptionHandler(OtpIncorrectException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ApiError handleOtpIncorrect(OtpIncorrectException ex) {
+        ApiError.ErrorInfo errorInfo = new ApiError.ErrorInfo();
         errorInfo.setMessage(ex.getMessage());
         return ApiError.builder()
                 .errors(List.of(errorInfo)).build();

--- a/backend/src/main/java/com/bookstore/backend/orders/Order.java
+++ b/backend/src/main/java/com/bookstore/backend/orders/Order.java
@@ -31,7 +31,8 @@ public class Order  {
     @Embedded(onEmpty = Embedded.OnEmpty.USE_NULL)
     private UserInformation userInformation;
     /*End user information*/
-
+    private Long otp;
+    private Instant otpExpiredAt;
     @CreatedDate
     private Instant createdDate;
     @CreatedBy

--- a/backend/src/main/java/com/bookstore/backend/orders/OrderRepository.java
+++ b/backend/src/main/java/com/bookstore/backend/orders/OrderRepository.java
@@ -5,12 +5,15 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 @Repository
 public interface OrderRepository extends CrudRepository<Order, UUID> {
 
     Page<Order> findAllByCreatedBy(String createdBy, Pageable pageable);
+
+    Optional<Order> findByIdAndOtp(UUID id, long otp);
 
     Page<Order> findAllByStatus(OrderStatus status, Pageable pageable);
 }

--- a/backend/src/main/java/com/bookstore/backend/orders/dto/OrderUpdateDto.java
+++ b/backend/src/main/java/com/bookstore/backend/orders/dto/OrderUpdateDto.java
@@ -1,0 +1,13 @@
+package com.bookstore.backend.orders.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.validation.Valid;
+
+@Getter
+@Setter
+public class OrderUpdateDto {
+    @Valid
+    private UserInformation userInformation;
+}

--- a/backend/src/main/java/com/bookstore/backend/orders/dto/OtpRequestDto.java
+++ b/backend/src/main/java/com/bookstore/backend/orders/dto/OtpRequestDto.java
@@ -1,0 +1,10 @@
+package com.bookstore.backend.orders.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class OtpRequestDto {
+    private Long otp;
+}

--- a/backend/src/main/java/com/bookstore/backend/orders/exception/OrderStatusNotMatchException.java
+++ b/backend/src/main/java/com/bookstore/backend/orders/exception/OrderStatusNotMatchException.java
@@ -1,0 +1,11 @@
+package com.bookstore.backend.orders.exception;
+
+import com.bookstore.backend.orders.OrderStatus;
+
+import java.util.UUID;
+
+public class OrderStatusNotMatchException extends RuntimeException {
+    public OrderStatusNotMatchException(UUID orderId, OrderStatus expectedStatus, OrderStatus actualStatus) {
+        super(String.format("Order %s status must be %s, not %s", orderId, expectedStatus, actualStatus));
+    }
+}

--- a/backend/src/main/java/com/bookstore/backend/orders/exception/OtpExpiredException.java
+++ b/backend/src/main/java/com/bookstore/backend/orders/exception/OtpExpiredException.java
@@ -1,0 +1,9 @@
+package com.bookstore.backend.orders.exception;
+
+import java.util.UUID;
+
+public class OtpExpiredException extends RuntimeException {
+    public OtpExpiredException(UUID orderId) {
+        super("Order with id " + orderId + " has expired OTP");
+    }
+}

--- a/backend/src/main/java/com/bookstore/backend/orders/exception/OtpIncorrectException.java
+++ b/backend/src/main/java/com/bookstore/backend/orders/exception/OtpIncorrectException.java
@@ -1,0 +1,9 @@
+package com.bookstore.backend.orders.exception;
+
+import java.util.UUID;
+
+public class OtpIncorrectException extends RuntimeException {
+    public OtpIncorrectException(UUID orderId) {
+        super("Otp is incorrect for order with id: " + orderId);
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -28,6 +28,19 @@ spring:
       resourceserver:
         jwt:
           issuer-uri: http://localhost:8080/realms/bookstore
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: nguyennt11032004@gmail.com
+    password: lwox kogu lkqj bome
+    properties:
+      mail:
+        smtp:
+          auth: true
+          connectiontimeout: 15000
+          timeout: 15000
+          starttls:
+            enable: true
 
 bookstore:
   cloudinary:

--- a/backend/src/main/resources/db/migration/V1__Initial_schema.sql
+++ b/backend/src/main/resources/db/migration/V1__Initial_schema.sql
@@ -54,6 +54,8 @@ CREATE table orders
     city               varchar(255) not null,
     zip_code           varchar(255) not null,
     address            varchar(255) not null,
+    otp                bigint null,
+    otp_expired_at     timestamp null,
     created_date       timestamp    not null,
     created_by         varchar(255),
     last_modified_date timestamp    not null,

--- a/bookstore-ui/src/app/shared/component/user-information-form-dialog/user-information-form-dialog.component.css
+++ b/bookstore-ui/src/app/shared/component/user-information-form-dialog/user-information-form-dialog.component.css
@@ -1,0 +1,37 @@
+.full-width {
+  width: 100%;
+}
+
+.user-info-card {
+  min-width: 120px;
+  margin: 20px auto;
+}
+
+.mat-radio-button {
+  display: block;
+  margin: 5px 0;
+}
+
+.row {
+  display: flex;
+  flex-direction: row;
+}
+
+.col {
+  flex: 1;
+  margin-right: 20px;
+}
+
+.col:last-child {
+  margin-right: 0;
+}
+
+.card-actions {
+  text-align: right;
+}
+
+.mat-card-header {
+  display: block;
+  margin: auto;
+  text-align: center;
+}

--- a/bookstore-ui/src/app/shared/component/user-information-form-dialog/user-information-form-dialog.component.html
+++ b/bookstore-ui/src/app/shared/component/user-information-form-dialog/user-information-form-dialog.component.html
@@ -1,0 +1,39 @@
+<form [formGroup]="userInfoForm" novalidate (ngSubmit)="onButtonClicked()">
+  <mat-card class="user-info">
+    <mat-card-header>
+      <mat-card-title>Edit User Information</mat-card-title>
+    </mat-card-header>
+    <mat-card-content>
+      <div class="row">
+        <div class="col">
+          <mat-form-field class="full-width">
+            <textarea matInput placeholder="Address" formControlName="address"></textarea>
+          </mat-form-field>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col">
+          <mat-form-field class="full-width">
+            <mat-select placeholder="City" formControlName="city" [compareWith]="compareFn">
+              @for (city of cities; track city) {
+                <mat-option [value]="city.name">{{ city.name }}</mat-option>
+              }
+            </mat-select>
+          </mat-form-field>
+        </div>
+        <div class="col">
+          <mat-form-field class="full-width">
+            <input matInput placeholder="Zipcode" formControlName="zipCode">
+            @if (userInfoForm.controls['zipCode'].hasError('pattern')) {
+              <mat-error>Zipcode is <strong>invalid</strong></mat-error>
+            }
+          </mat-form-field>
+        </div>
+      </div>
+    </mat-card-content>
+    <mat-card-actions>
+      <button mat-raised-button color="primary" type="submit">Update</button>
+      <button mat-raised-button color="primary" (click)="onCancel()" type="button">Cancel</button>
+    </mat-card-actions>
+  </mat-card>
+</form>

--- a/bookstore-ui/src/app/shared/component/user-information-form-dialog/user-information-form-dialog.component.ts
+++ b/bookstore-ui/src/app/shared/component/user-information-form-dialog/user-information-form-dialog.component.ts
@@ -1,0 +1,97 @@
+import {Component, EventEmitter, Inject, inject, Input, Output} from '@angular/core';
+import {MatCardModule} from "@angular/material/card";
+import {MatInputModule} from "@angular/material/input";
+import {UserInformation} from "../../model/user-information";
+import {FormControl, FormGroup, FormsModule, ReactiveFormsModule, Validators} from "@angular/forms";
+import {cities} from "../../model/cities";
+import {MatOption} from "@angular/material/core";
+import {MatRadioButton, MatRadioGroup} from "@angular/material/radio";
+import {MatSelect} from "@angular/material/select";
+import {MatButtonModule} from "@angular/material/button";
+import {MAT_DIALOG_DATA, MatDialogRef} from "@angular/material/dialog";
+import {PurchaseOrderService} from "../../service/purchase-order.service";
+import {Order} from "../../model/order";
+import {SnackbarService} from "../../service/snackbar.service";
+import {CustomError} from "../../model/api-error";
+
+@Component({
+  selector: 'app-user-information-form',
+  standalone: true,
+  imports: [
+    MatCardModule,
+    MatInputModule,
+    FormsModule,
+    MatOption,
+    MatRadioButton,
+    MatRadioGroup,
+    MatSelect,
+    ReactiveFormsModule,
+    MatButtonModule
+  ],
+  templateUrl: './user-information-form-dialog.component.html',
+  styleUrl: './user-information-form-dialog.component.css'
+})
+export class UserInformationFormDialog {
+
+  private orderService = inject(PurchaseOrderService)
+  private snackBarService = inject(SnackbarService)
+
+  orderDetail: Order | undefined;
+
+  constructor(
+    public dialogRef: MatDialogRef<UserInformationFormDialog>,
+    @Inject(MAT_DIALOG_DATA) public data: Order,
+  ) {
+    this.orderDetail = data;
+  }
+
+  onButtonClicked(): void {
+    const address = this.userInfoForm.value.address ?? '';
+    const city = this.userInfoForm.value.city ?? '';
+    const zipCode = this.userInfoForm.value.zipCode ?? '';
+
+    if (this.userInfoForm
+      && (address.length > 0 || city.length > 0 || zipCode.length > 0)
+      && this.orderDetail
+    ) {
+      this.orderDetail.userInformation = {
+        address: address.length > 0 ? address : this.orderDetail.userInformation.address,
+        city: city.length > 0 ? city : this.orderDetail.userInformation.city,
+        zipCode: zipCode.length > 0 ? zipCode : this.orderDetail.userInformation.zipCode,
+        fullName: this.orderDetail.userInformation.fullName,
+        email: this.orderDetail.userInformation.email,
+        phoneNumber: this.orderDetail.userInformation.phoneNumber,
+      }
+      this.orderService.updateOrder(this.orderDetail).subscribe({
+        next: () => {
+          this.snackBarService.show("Update Order successfully")
+          this.dialogRef.close()
+        },
+        error: err => {
+          if (err && err.errors) {
+            err.errors.forEach((err: CustomError) => this.snackBarService.show(err.message))
+          }
+        }
+      })
+    } else {
+      this.snackBarService.show("Cancel update success!")
+      this.dialogRef.close()
+    }
+  }
+
+  userInfoForm = new FormGroup({
+    address: new FormControl(''),
+    city: new FormControl(''),
+    zipCode: new FormControl('', Validators.pattern(/^\d{5}(?:[-\s]\d{4})?$/))
+  })
+
+  compareFn(c1: any, c2: any): boolean {
+    return c1 && c2 ? c1.name === c2.name : c1 === c2;
+  }
+
+  protected readonly cities = cities;
+
+  onCancel() {
+    this.dialogRef.close()
+  }
+}

--- a/bookstore-ui/src/app/shared/service/purchase-order.service.ts
+++ b/bookstore-ui/src/app/shared/service/purchase-order.service.ts
@@ -23,4 +23,16 @@ export class PurchaseOrderService {
   getOrderByOrderId(orderId: string): Observable<Order> {
     return this.http.get<Order>(`/api/orders/${orderId}`);
   }
+
+  sendOTP(orderId: string) {
+    return this.http.get(`/api/orders/${orderId}/send-opt`);
+  }
+
+  verifyOTP(orderId: string, otp: string): Observable<Order> {
+    return this.http.post<Order>(`/api/orders/${orderId}/verify-otp`, {otp: otp});
+  }
+
+  updateOrder(orderDetail: Order) {
+    return this.http.patch<Order>(`/api/orders/${orderDetail.id}`, orderDetail)
+  }
 }

--- a/bookstore-ui/src/app/shopping/checkout/checkout.component.ts
+++ b/bookstore-ui/src/app/shopping/checkout/checkout.component.ts
@@ -102,6 +102,8 @@ export class CheckoutComponent {
                   }
                 }
               });
+            } else {
+              this.router.navigate(['/payment-callback-detail', order.id])
             }
           },
           error: err => {

--- a/bookstore-ui/src/app/shopping/payment-callback-detail/payment-callback-detail.component.html
+++ b/bookstore-ui/src/app/shopping/payment-callback-detail/payment-callback-detail.component.html
@@ -7,6 +7,9 @@
       @if(orderDetail.status == 'PAYMENT_FAILED') {
         <span style="color: #ff0000">Your order has not been successfully paid yet</span>
       }
+      @if(orderDetail.status === 'WAITING_FOR_ACCEPTANCE') {
+        <span style="color: #ff0000">Your order is waiting for acceptance, please verify email</span>
+      }
     </mat-card-title>
   </mat-card-header>
   <mat-card-content>
@@ -14,6 +17,27 @@
     <mat-card-subtitle>
       @if(orderDetail.status == 'PAYMENT_FAILED') {
         <button mat-raised-button (click)="onRepayment(orderDetail.id)">Repayment</button>
+      }
+      @if(orderDetail.status == 'WAITING_FOR_ACCEPTANCE') {
+        <button mat-raised-button [disabled]="isSendingOtp" (click)="sendOtp(orderDetail.id)">
+          <span *ngIf="isSendingOtp">Resend ... {{timeRemaining}} s</span>
+          <span *ngIf="!isSendingOtp">Send OTP</span>
+        </button>
+
+        <form [formGroup]="otpFormGroup">
+          <mat-form-field>
+            <input matInput placeholder="OTP" formControlName="otp">
+            @if (otpFormGroup.controls['otp'].hasError('required')) {
+              <mat-error>Otp is <strong>required</strong></mat-error>
+            }
+            @if (otpFormGroup.controls['otp'].hasError('pattern')) {
+              <mat-error>Otp is <strong> number with 6 digits</strong></mat-error>
+            }
+          </mat-form-field>
+          <button mat-raised-button [disabled]="isVerifyingOtp" (click)="verifyOtp(orderDetail.id)">
+            {{ isVerifyingOtp ? 'Verifying...' : 'Verify OTP' }}
+          </button>
+        </form>
       }
     </mat-card-subtitle>
     <br>
@@ -25,13 +49,14 @@
             Total price: {{orderDetail.totalPrice | currency:'VND':'symbol':'1.0-0'}}
           </mat-panel-description>
         </mat-expansion-panel-header>
-        <p>User Information: <br>
+        <p>User Information: <button mat-icon-button (click)="updateOrder()"><mat-icon>edit</mat-icon></button><br>
           <span matListItemLine>Full name: {{orderDetail.userInformation.fullName}}</span>
           <span matListItemLine>Email: {{orderDetail.userInformation.email}}</span>
           <span matListItemLine>Phone number: {{orderDetail.userInformation.phoneNumber}}</span>
           <span matListItemLine>City: {{orderDetail.userInformation.city}}</span>
           <span matListItemLine>Zipcode: {{orderDetail.userInformation.zipCode}}</span>
           <span matListItemLine>Address: {{orderDetail.userInformation.address}}</span>
+          <span matListItemLine style="font-weight: bold">Payment method: {{orderDetail.paymentMethod}}</span>
         </p>
 
         <p>Order items:</p>

--- a/gateway/src/main/java/com/bookstore/gateway/config/SecurityConfig.java
+++ b/gateway/src/main/java/com/bookstore/gateway/config/SecurityConfig.java
@@ -35,6 +35,7 @@ public class SecurityConfig {
                         .pathMatchers("/", "/index.html", "/*.css", "/*.js", "/favicon.ico", "/@fs/**", "/@vite/client").permitAll()
                         .pathMatchers(HttpMethod.GET, "/api/**", "/shopping-carts/**", "/payment-callback-detail/**").permitAll()
                         .pathMatchers(HttpMethod.POST, "/api/orders/**").permitAll()
+                        .pathMatchers(HttpMethod.PATCH, "/api/orders/**").permitAll()
                         .anyExchange().authenticated())
                 .exceptionHandling(exceptionHandling -> exceptionHandling
                         .authenticationEntryPoint(new HttpStatusServerEntryPoint(HttpStatus.UNAUTHORIZED)))


### PR DESCRIPTION
backend: Tích hợp gmail để gửi thông báo đơn hàng 
backend: Order domain update 2 thuộc tính là otp và otp expired
backend: Order controller add 2 endpoint: send-otp, verify-otp 
ui:checkout-component.ts: Xử lý trường hợp `cash` để đồng bộ với vnpay -> đều chuyển tới route (order-callback-detail- hiện đang có tên là **payment-callback-detail**) 
ui:payment-callback-detail.component.* update giao diện cho các đơn hàng thuộc CASH
gateway: update security config
ui: create a new component: userinformation-dialog để cập nhật thông tin đơn hàng khi đã tạo, chỉ cho cập nhật địa chỉ, zipcode, thành phố